### PR TITLE
feat: persist wallet choice + global state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,18 +23,20 @@ working on GrowPod Empire. Update it as decisions and context change.
 
 ## Known TypeScript Errors (baseline = 14, tolerated by CI)
 CI (`pr-validation.yml`) hard-codes `ALLOWED_ERRORS=14` and only fails if the
-count *increases*. Root cause: seed-object type inference. These are NOT to be
-treated as blocked, but should shrink over time.
+count *increases*. These are NOT to be treated as blocked, but should shrink
+over time.
 
-| # | File | Area |
-|---|------|------|
-| 1-? | `client/src/pages/CombinerLab.tsx` | `userSeed.seed.*` access — `SeedBankItem` relation not inferred |
-| 1-? | `client/src/pages/Dashboard.tsx` | `(UserSeed & { seed: SeedBankItem })` typing in state/query/handlers |
-| 1-? | `client/src/pages/SeedVault.tsx` | `userSeed.seed.rarity` / `.name` access type inference |
+> Verified 2026-07-17 after `npm install`: `tsc` reported **5** errors, all in
+> `client/src/hooks/use-algorand.ts` (`foreignAssets` should be
+> `appForeignAssets` on `addMethodCall`). Zero errors in WalletContext/pages.
+> Down from the historical 14 — keep count from increasing.
 
-> Exact per-file counts were not reproducible in this session (`tsc` not
-> installed in the sandbox). Re-run `npm run check` after `npm install` to get
-> precise line numbers and update this table. Total confirmed baseline: 14.
+| File | Area | Count |
+|------|------|-------|
+| `client/src/hooks/use-algorand.ts` | `foreignAssets` vs `appForeignAssets` in `addMethodCall` (harvest/cleanup/checkTerp/claimSlot/unlockSlot) | 5 |
+| `client/src/pages/CombinerLab.tsx` | `userSeed.seed.*` access — `SeedBankItem` relation not inferred | (historical) |
+| `client/src/pages/Dashboard.tsx` | `(UserSeed & { seed: SeedBankItem })` typing in state/query/handlers | (historical) |
+| `client/src/pages/SeedVault.tsx` | `userSeed.seed.rarity` / `.name` access type inference | (historical) |
 
 ## Decisions & Context
 - `main` is the single source of truth; all AI work merges back via reviewed PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md — Memory & Operating Rules
+
+This file is the persistent memory layer for AI agents (Kilo, Claude, Copilot)
+working on GrowPod Empire. Update it as decisions and context change.
+
+## Project Snapshot
+- **Name**: GrowPod Empire v2.0 — blockchain idle/farming game on Algorand TestNet.
+- **Stack**: React 18 + Vite + TS (frontend), Express + Drizzle + PostgreSQL
+  (backend), TEALScript/PyTeal (Algorand contracts).
+- **Deploy**: Cloudflare Workers (`deploy-cloudflare.yml`) + Vercel analytics.
+- **Wallet**: Pera Wallet Connect (multi-wallet planned — see ROADMAP.md).
+- **Repo conventions**: `@/` → `client/src/`, `@shared/` → `shared/`; TanStack
+  Query for API calls; shadcn/ui; Tailwind dark cyberpunk theme.
+
+## Operating Rules (USER PREFERENCES)
+- **NEVER auto-merge.** No merge to `main` without explicit user approval.
+- **NEVER open a PR** without explicit user approval.
+- **Human in the loop**: propose intent → user approves → implement → report.
+- Keep work on a clearly named branch (`kilo/<task>`, or `feature/*`/`fix/*`).
+- Run `npm run check` + `npm run build` before declaring done (14 known errors
+  are tolerated by CI — see below — but do not introduce new ones).
+- No hardcoded secrets; use `import.meta.env.VITE_*` and server env vars.
+
+## Known TypeScript Errors (baseline = 14, tolerated by CI)
+CI (`pr-validation.yml`) hard-codes `ALLOWED_ERRORS=14` and only fails if the
+count *increases*. Root cause: seed-object type inference. These are NOT to be
+treated as blocked, but should shrink over time.
+
+| # | File | Area |
+|---|------|------|
+| 1-? | `client/src/pages/CombinerLab.tsx` | `userSeed.seed.*` access — `SeedBankItem` relation not inferred |
+| 1-? | `client/src/pages/Dashboard.tsx` | `(UserSeed & { seed: SeedBankItem })` typing in state/query/handlers |
+| 1-? | `client/src/pages/SeedVault.tsx` | `userSeed.seed.rarity` / `.name` access type inference |
+
+> Exact per-file counts were not reproducible in this session (`tsc` not
+> installed in the sandbox). Re-run `npm run check` after `npm install` to get
+> precise line numbers and update this table. Total confirmed baseline: 14.
+
+## Decisions & Context
+- `main` is the single source of truth; all AI work merges back via reviewed PR.
+- Smart contracts converted PyTeal → TEALScript (`contracts/GrowPodEmpire.algo.ts`).
+- Repo consistency enforced by `scripts/validate-consistency.js` +
+  `validation-config.json` (see `VALIDATION_*.md`).
+- No AI memory layer, no HERMES/agent orchestration exists in this repo.
+
+## Recent User Requests
+- Audited repo for memory layer / HERMES / workflow / roadmap (no such systems found).
+- Requested workflow improvements; created `ROADMAP.md` + this `AGENTS.md`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,57 @@
+# ROADMAP.md
+
+GrowPod Empire — prioritized work list.
+
+> Source: Carried over from the interrupted PR described in
+> `.github/instructions/*.instructions.md` (6 pending items), plus ongoing
+> tech-debt tracked in `AGENTS.md`. Human-in-the-loop only: nothing here is
+> started without explicit approval (see `AGENTS.md` → Operating Rules).
+
+## Status
+- Project: v2.0 idle/farming game on Algorand TestNet (head: `56109e9`).
+- Workflow: AI-assisted PRs to `main` (Copilot/Claude branches). CI tolerates
+  14 known TypeScript errors (see `AGENTS.md`).
+- Branch hygiene: ~55 stale remote branches — cleanup is recommended before
+  new work (see `scripts/cleanup-branches.sh`).
+
+## Priority 1 — Pending items (from interrupted PR)
+Ordered by user-facing impact. These are the 6 items the agent was mid-flight on.
+
+1. **Multi-wallet support**
+   - Enhance Pera Wallet connection and add Defly (via WalletConnect) + other
+     WalletConnect-compatible wallets.
+   - Files: `client/src/context/AlgorandContext.tsx`, `client/src/hooks/use-algorand.ts`.
+
+2. **Remove "Fast Mode" button**
+   - Clean up homepage by removing the unnecessary water-throttling control while
+     keeping the underlying functionality intact.
+   - Files: `client/src/pages/Dashboard.tsx`, Navigation/components.
+
+3. **Fix song upload**
+   - Repair metadata extraction and ensure audio files upload properly to the
+     Jukebox (Replit Object Storage / signed URLs).
+   - Files: `client/src/pages/Jukebox.tsx`, `server/routes.ts`, `server/replit_integrations/object_storage/`.
+
+4. **Button hover effects**
+   - Add subtle glowing hover effects to buttons throughout the app for better
+     visual feedback.
+   - Files: `client/src/components/ui/button.tsx`, shared Tailwind utilities.
+
+5. **Enhanced landing page**
+   - Make the welcome screen more informative/visually appealing with feature
+     showcases.
+   - Files: landing/home page component.
+
+6. **TypeScript improvements**
+   - Fix type definitions throughout the codebase (shrink the 14-error baseline
+     in `AGENTS.md`). Can be done incrementally alongside other items.
+
+## Priority 2 — Tech debt (tracked in AGENTS.md)
+- Reduce the 14 known TS errors to 0 (CombinerLab, Dashboard, SeedVault).
+- Consolidate/delete ~55 stale `copilot/*` and `claude/*` branches.
+- Add a real memory/context layer (no cross-session memory currently exists).
+
+## Priority 3 — Possible future (not yet committed)
+- Mainnet considerations (currently TestNet only).
+- Additional pod slots / breeding mechanics polish.
+- Expanded community/achievements features.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,10 +17,13 @@ GrowPod Empire — prioritized work list.
 ## Priority 1 — Pending items (from interrupted PR)
 Ordered by user-facing impact. These are the 6 items the agent was mid-flight on.
 
-1. **Multi-wallet support**
-   - Enhance Pera Wallet connection and add Defly (via WalletConnect) + other
-     WalletConnect-compatible wallets.
-   - Files: `client/src/context/AlgorandContext.tsx`, `client/src/hooks/use-algorand.ts`.
+1. **Multi-wallet support** — ✅ Already implemented.
+   - Pera + Defly (WalletConnect) both wired in `AlgorandContext.tsx`,
+     `WalletSelector.tsx` offers both, Navigation shows active wallet.
+   - **Done (2026-07-17)**: added `localStorage` persistence of the
+     last-used wallet type so a fresh reload restores the correct session
+     globally (prefers stored wallet, falls back to the other). Non-breaking.
+     Files: `client/src/context/AlgorandContext.tsx`.
 
 2. **Remove "Fast Mode" button**
    - Clean up homepage by removing the unnecessary water-throttling control while

--- a/client/src/context/AlgorandContext.tsx
+++ b/client/src/context/AlgorandContext.tsx
@@ -23,6 +23,31 @@ export const CONTRACT_CONFIG = {
 
 export const algodClient = new algosdk.Algodv2(ALGOD_TOKEN, ALGOD_SERVER, '');
 
+// Persist the last-used wallet so a fresh page load can restore the
+// correct session globally instead of always defaulting to Pera.
+const WALLET_STORAGE_KEY = 'growpod_wallet';
+
+function getStoredWalletType(): WalletType {
+  try {
+    const stored = localStorage.getItem(WALLET_STORAGE_KEY);
+    return stored === 'pera' || stored === 'defly' ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+function setStoredWalletType(type: WalletType) {
+  try {
+    if (type) {
+      localStorage.setItem(WALLET_STORAGE_KEY, type);
+    } else {
+      localStorage.removeItem(WALLET_STORAGE_KEY);
+    }
+  } catch {
+    // ignore storage failures (private mode, etc.)
+  }
+}
+
 // Lazy-initialize wallet connectors to avoid module-level failures
 // if polyfills (Buffer, global, process) haven't loaded yet
 let _peraWallet: PeraWalletConnect | null = null;
@@ -87,34 +112,34 @@ export function AlgorandProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
 
     const reconnect = async () => {
-      // Try Pera first
-      try {
-        const peraAccounts = await getPeraWallet().reconnectSession();
-        if (!cancelled && peraAccounts.length) {
-          const address = peraAccounts[0];
-          setAccount(address);
-          setIsConnected(true);
-          setWalletType('pera');
-          await syncWithBackend(address);
-          return; // Pera connected, skip Defly
-        }
-      } catch (err) {
-        console.error('Pera reconnect failed:', err);
-      }
+      const preferred = getStoredWalletType();
+      const first: WalletType = preferred ?? 'pera';
+      const second: WalletType = first === 'pera' ? 'defly' : 'pera';
 
-      // Try Defly if Pera didn't connect
-      try {
-        const deflyAccounts = await getDeflyWallet().reconnectSession();
-        if (!cancelled && deflyAccounts.length) {
-          const address = deflyAccounts[0];
-          setAccount(address);
-          setIsConnected(true);
-          setWalletType('defly');
-          await syncWithBackend(address);
+      const tryReconnect = async (type: WalletType): Promise<boolean> => {
+        if (!type) return false;
+        try {
+          const accounts = type === 'pera'
+            ? await getPeraWallet().reconnectSession()
+            : await getDeflyWallet().reconnectSession();
+          if (!cancelled && accounts.length) {
+            const address = accounts[0];
+            setAccount(address);
+            setIsConnected(true);
+            setWalletType(type);
+            setStoredWalletType(type);
+            await syncWithBackend(address);
+            return true;
+          }
+        } catch (err) {
+          console.error(`${type} reconnect failed:`, err);
         }
-      } catch (err) {
-        console.error('Defly reconnect failed:', err);
-      }
+        return false;
+      };
+
+      // Prefer the last-used wallet, then fall back to the other
+      if (await tryReconnect(first)) return;
+      await tryReconnect(second);
     };
 
     reconnect();
@@ -164,6 +189,7 @@ export function AlgorandProvider({ children }: { children: ReactNode }) {
       setAccount(address);
       setIsConnected(true);
       setWalletType(type);
+      setStoredWalletType(type);
 
       // Sync with backend (non-blocking, don't let failure prevent connection)
       syncWithBackend(address).catch(() => {});
@@ -197,6 +223,7 @@ export function AlgorandProvider({ children }: { children: ReactNode }) {
       setAccount(null);
       setIsConnected(false);
       setWalletType(null);
+      setStoredWalletType(null);
       queryClient.clear();
       toast({ title: "Wallet Disconnected" });
     } catch (error) {


### PR DESCRIPTION
## Summary
- Add localStorage persistence of last-used wallet type (Pera/Defly) in AlgorandContext.tsx so a fresh reload restores the correct session globally.
- Reconnect prefers the stored wallet, falls back to the other.
- Add AGENTS.md (memory layer) and ROADMAP.md (prioritized tasks).

## Verification
- npm run check: 5 errors total, all pre-existing in use-algorand.ts (foreignAssets vs appForeignAssets), 0 in AlgorandContext.tsx. Within CI baseline of 14.
- npm run build: success (exit 0).

## Note
Does NOT merge automatically. Awaiting human approval per repo rules.